### PR TITLE
drivers: sensor: rm3100: use edge based interrupts

### DIFF
--- a/drivers/sensor/pni/rm3100/rm3100.h
+++ b/drivers/sensor/pni/rm3100/rm3100.h
@@ -10,6 +10,7 @@
 
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/sys/atomic.h>
 #include <zephyr/rtio/rtio.h>
 #include <zephyr/rtio/regmap.h>
 #include "rm3100_reg.h"
@@ -46,6 +47,7 @@ struct rm3100_stream {
 	struct gpio_callback cb;
 	const struct device *dev;
 	struct rtio_iodev_sqe *iodev_sqe;
+	atomic_t armed;
 	struct {
 		struct {
 			bool drdy : 1;


### PR DESCRIPTION
The rm3100 streaming logic currently relies on using its interrupt pin as a level based interrupt. Edge based interrupts can also be used provided some initial polling of the pin is done to check if it is active already. Considering that hardware support for edge based interrupts is more frequent than level based interrupts, using edge is desirable as it makes the driver compatible with a wider range of devices. As a result, convert the current logic to use edge based interrupts.

This is just for us to review the driver internally before a PR on upstream zephyr is opened. No code will actually get merged into our fork.